### PR TITLE
fix: replace cassandra-driver with @scylladb/driver in JS example

### DIFF
--- a/docs/source/build-with-javascript.md
+++ b/docs/source/build-with-javascript.md
@@ -4,12 +4,12 @@ In this tutorial you'll build a Media Player to store your songs and build playl
 
 ## 1. Getting the Driver
 
-Install the [JavaScript Cassandra driver](https://github.com/datastax/nodejs-driver/) that also works with ScyllaDB.
+Install the [ScyllaDB Node.js RS Driver](https://github.com/scylladb/nodejs-rs-driver), a native ScyllaDB driver built on top of the ScyllaDB Rust driver.
 
 ```sh
-$ npm install cassandra-driver
+$ npm install @scylladb/driver
 
-$ yarn install cassandra-driver
+$ yarn add @scylladb/driver
 ```
 
 ## 2. Connect to the cluster

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('dotenv').config();
-const cassandra = require('cassandra-driver');
+const cassandra = require('@scylladb/driver');
 const readline = require('readline');
 
 // Line reader that works correctly with both interactive TTY and piped stdin.

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,7 +7,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "cassandra-driver": "^4.7.2",
+    "@scylladb/driver": "^0.6.1",
     "dotenv": "^16.4.5"
   }
 }


### PR DESCRIPTION
Switch JS example to Rust-based ScyllaDB driver.

Fixes #68